### PR TITLE
Allow types to declare their table name.

### DIFF
--- a/src/dsl.zig
+++ b/src/dsl.zig
@@ -306,6 +306,7 @@ pub fn Select(comptime T: type, comptime sel: []const std.meta.FieldEnum(T)) typ
 
 fn tableName(comptime T: type) []const u8 {
     return comptime brk: {
+        if (@hasDecl(T, "sql_table_name")) break :brk T.sql_table_name;
         const s = @typeName(T);
         const i = std.mem.lastIndexOfScalar(u8, s, '.').?;
         break :brk s[i + 1 ..];


### PR DESCRIPTION
Some types may be direct descendants of another type, but have its contents exist on a different table. For instance, there may be a table of `items`, and one might want to be able to add many tags to those items, so they might have a `item_tags` table associated with it. In Zig code the most logical way to represent this would be a `Item` type, and a `Tag` type name-spaced within it, like `Item.Tag`. The current code would require two unrelated types, `Items` & `ItemTags`, especially if there might be an `Item2` with its own associated tags.

This allows a user to optionally change the table name for a given type, by setting a declaration:

```zig
pub const Item = struct {
    name: []const u8,
    pub const sql_table_name = "items";

    pub const Tag = struct {
        name: []const u8,
        pub const sql_table_name = "item_tags";
    }
}
```

Figured it made sense to give it a name that wasn't likely to be used otherwise, although maybe `table_name` would have sufficed?