### PR TITLE
Made sqlite_source a lazy dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,9 +13,10 @@ pub fn build(b: *std.Build) !void {
     lib.link_libc = true;
 
     if (bundle) {
-        const src = b.dependency("sqlite_source", .{});
-        lib.addIncludePath(src.path("."));
-        lib.addCSourceFile(.{ .file = src.path("sqlite3.c"), .flags = &.{"-std=c99"} });
+        if (b.lazyDependency("sqlite_source", .{})) |src| {
+            lib.addIncludePath(src.path("."));
+            lib.addCSourceFile(.{ .file = src.path("sqlite3.c"), .flags = &.{"-std=c99"} });
+        }
     } else {
         // lib.linkSystemLibrary("sqlite3", .{});
         try lib.link_objects.append(b.allocator, .{

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -90,7 +90,7 @@ pub fn Pool(comptime T: type) type {
             // Notify all waiting threads that the pool is closing
             self.wait.broadcast();
 
-            // Now we can aquire the mutex and continue without worying about deadlocks
+            // Now we can acquire the mutex and continue without worying about deadlocks
             self.mutex.lock();
             defer self.mutex.unlock();
 


### PR DESCRIPTION
I made sqlite_source a `lazyDependency` so a user of the library that doesn't bundle it does not need to download extra files. 

I have tested using zig 0.15.2

I also fixed a small typo